### PR TITLE
update README: add CI/CD section, live URL, replace Vercel w/ Netlify 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 TaskKernel is a gamified progress tracker web app for students and everyday users who want a simple way to build habits, develop skills, and stay consistent. Users create tasks, check them off each day, and earn progression through a leveling system and rewards.
 
+## Live Demo
+
+[taskkernel.netlify.app](https://taskkernel.netlify.app)
+
+## CI/CD Pipeline
+
+This project uses GitHub Actions for continuous integration and Netlify for continuous deployment.
+
+- Every push to `main` automatically triggers the CI pipeline
+- The pipeline installs dependencies and builds the React app
+- Netlify auto-deploys the frontend on every successful push to `main`
+- Any team member can push a change and see it live within minutes
+
 ## Features
 
 - Create tasks/goals with a target frequency (days per week)
@@ -15,11 +28,13 @@ TaskKernel is a gamified progress tracker web app for students and everyday user
 - Frontend: React + Tailwind CSS
 - Backend: Spring Boot + JWT authentication
 - Database: PostgreSQL
-- Deployment: Vercel (frontend), Render (backend)
+- Deployment: Netlify (frontend), Render (backend)
+- CI/CD: GitHub Actions
 
 ## Roadmap
 
 **Phase 1 (MVP):**
+
 - Login / registration
 - Create / edit / delete tasks
 - Daily completion checkboxes
@@ -27,6 +42,7 @@ TaskKernel is a gamified progress tracker web app for students and everyday user
 - Basic progression (XP per completion)
 
 **Phase 2 (Game Mechanics):**
+
 - Level thresholds
 - Streak tracking
 - Achievement badges
@@ -34,14 +50,15 @@ TaskKernel is a gamified progress tracker web app for students and everyday user
 - Visual character/avatar progression
 
 **Phase 3 (Polish):**
+
 - Animations for completions
 - Mobile responsive layout
 - Better visualizations
 
 ## Repository Structure
 
-- frontend/ –> React user interface  
-- backend/ –> Server/API (future development)  
+- frontend/ –> React user interface
+- backend/ –> Server/API (future development)
 - docs/ –> Sprint notes and class artifacts
 
 ## How to Run
@@ -49,9 +66,10 @@ TaskKernel is a gamified progress tracker web app for students and everyday user
 > This project is under active development. Frontend setup is available now; backend setup will be added in a future sprint.
 
 ### Prerequisites
+
 - Git
 - Node.js (LTS) + npm
-- Java 17 *(backend planned)*
+- Java 17 _(backend planned)_
 
 ### Frontend
 


### PR DESCRIPTION
Updates README to reflect current project status. Replaces Vercel with Netlify as our deployment platform, adds live demo URL (taskkernel.netlify.app), and adds a CI/CD Pipeline section explaining how our GitHub Actions workflow and Netlify auto-deployment work together. Also cleaned up formatting throughout.