### PR TITLE
Add minimal Spring Boot backend with /health endpoint

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.taskkernel</groupId>
+  <artifactId>backend</artifactId>
+  <version>0.0.1</version>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.5</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/backend/src/main/java/com/taskkernel/Application.java
+++ b/backend/src/main/java/com/taskkernel/Application.java
@@ -1,0 +1,13 @@
+package com.taskkernel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/backend/src/main/java/com/taskkernel/HealthController.java
+++ b/backend/src/main/java/com/taskkernel/HealthController.java
@@ -1,0 +1,15 @@
+package com.taskkernel;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/health")
+    public Map<String, String> health() {
+        return Map.of("status", "UP");
+    }
+
+}


### PR DESCRIPTION
Adds a minimal Spring Boot backend with a /health endpoint for the CI/CD demo. Prepares the repository for backend deployment and health monitoring without affecting the current frontend CI pipeline.