### PR TITLE
feat: frontend final - restyle modals, fix header stats, wire add tas…

### DIFF
--- a/frontend/src/pages/dashboard/components/AddTaskModal.jsx
+++ b/frontend/src/pages/dashboard/components/AddTaskModal.jsx
@@ -7,8 +7,7 @@ const initialFormState = {
   strength: "weak",
 };
 
-// Rate limiting constants (in milliseconds)
-const TASK_CREATION_COOLDOWN = 2000; // 2 seconds between task creations
+const TASK_CREATION_COOLDOWN = 2000;
 
 export default function AddTaskModal({ open, onClose, onCreate }) {
   const [form, setForm] = useState(initialFormState);
@@ -18,7 +17,6 @@ export default function AddTaskModal({ open, onClose, onCreate }) {
   useEffect(() => {
     if (open) {
       setForm(initialFormState);
-      // Check if still in cooldown when modal opens
       const lastCreationTime = localStorage.getItem("lastTaskCreationTime");
       if (lastCreationTime) {
         const timeSinceLastCreation = Date.now() - parseInt(lastCreationTime);
@@ -31,24 +29,17 @@ export default function AddTaskModal({ open, onClose, onCreate }) {
     }
   }, [open]);
 
-  // Handle cooldown countdown timer
   useEffect(() => {
     if (!isOnCooldown || cooldownRemaining <= 0) {
       setIsOnCooldown(false);
       setCooldownRemaining(0);
       return;
     }
-
-    const timer = setTimeout(() => {
-      setCooldownRemaining((prev) => prev - 1);
-    }, 1000);
-
+    const timer = setTimeout(() => setCooldownRemaining((prev) => prev - 1), 1000);
     return () => clearTimeout(timer);
   }, [isOnCooldown, cooldownRemaining]);
 
-  if (!open) {
-    return null;
-  }
+  if (!open) return null;
 
   const handleChange = (field) => (event) => {
     setForm((prev) => ({ ...prev, [field]: event.target.value }));
@@ -56,17 +47,9 @@ export default function AddTaskModal({ open, onClose, onCreate }) {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    
-    // Prevent submission during cooldown
-    if (isOnCooldown) {
-      return;
-    }
-    
-    if (!form.title.trim()) {
-      return;
-    }
+    if (isOnCooldown) return;
+    if (!form.title.trim()) return;
 
-    // Record task creation time for rate limiting
     localStorage.setItem("lastTaskCreationTime", Date.now().toString());
     setIsOnCooldown(true);
     setCooldownRemaining(2);
@@ -81,64 +64,64 @@ export default function AddTaskModal({ open, onClose, onCreate }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 px-4 py-6">
-      <div className="w-full max-w-xl rounded-[2rem] bg-white p-6 shadow-2xl ring-1 ring-slate-200">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#653d15]/40 px-4 py-6">
+      <div className="w-full max-w-xl rounded-[2rem] bg-[#fdf6e3] p-6 shadow-2xl ring-2 ring-[#dbb96a]">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-2xl font-semibold text-slate-900">Add Task</h2>
-            <p className="mt-1 text-sm text-slate-500">Create a new task with title, description, type, and strength.</p>
+            <h2 className="text-2xl font-bold text-[#653d15]">Add Task</h2>
+            <p className="mt-1 text-sm text-[#9a6530]">Create a new task with title, description, type, and strength.</p>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-full border border-slate-200 bg-slate-100 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-200"
+            className="rounded-full border-2 border-[#dbb96a] bg-[#f0ddb8] px-3 py-2 text-sm font-semibold text-[#653d15] hover:bg-[#dbb96a]"
           >
             Close
           </button>
         </div>
 
         <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
-          <label className="block text-sm font-medium text-slate-700">
+          <label className="block text-sm font-semibold text-[#653d15]">
             Title
             <input
               type="text"
               value={form.title}
               onChange={handleChange("title")}
               placeholder="Task title"
-              className="mt-2 w-full rounded-3xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+              className="mt-2 w-full rounded-3xl border-2 border-[#dbb96a] bg-[#f5e9cc] px-4 py-3 text-sm text-[#653d15] outline-none focus:border-[#e9a319] focus:ring-2 focus:ring-[#e9a319]/30 placeholder:text-[#b08040]"
             />
           </label>
 
-          <label className="block text-sm font-medium text-slate-700">
+          <label className="block text-sm font-semibold text-[#653d15]">
             Description
             <textarea
               value={form.description}
               onChange={handleChange("description")}
               placeholder="Task description"
               rows="4"
-              className="mt-2 w-full rounded-3xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+              className="mt-2 w-full rounded-3xl border-2 border-[#dbb96a] bg-[#f5e9cc] px-4 py-3 text-sm text-[#653d15] outline-none focus:border-[#e9a319] focus:ring-2 focus:ring-[#e9a319]/30 placeholder:text-[#b08040]"
             />
           </label>
 
           <div className="grid gap-4 sm:grid-cols-2">
-            <label className="block text-sm font-medium text-slate-700">
+            <label className="block text-sm font-semibold text-[#653d15]">
               Type
               <select
                 value={form.type}
                 onChange={handleChange("type")}
-                className="mt-2 w-full rounded-3xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+                className="mt-2 w-full rounded-3xl border-2 border-[#dbb96a] bg-[#f5e9cc] px-4 py-3 text-sm text-[#653d15] outline-none focus:border-[#e9a319] focus:ring-2 focus:ring-[#e9a319]/30"
               >
                 <option value="daily">Daily</option>
                 <option value="weekly">Weekly</option>
               </select>
             </label>
 
-            <label className="block text-sm font-medium text-slate-700">
+            <label className="block text-sm font-semibold text-[#653d15]">
               Strength
               <select
                 value={form.strength}
                 onChange={handleChange("strength")}
-                className="mt-2 w-full rounded-3xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+                className="mt-2 w-full rounded-3xl border-2 border-[#dbb96a] bg-[#f5e9cc] px-4 py-3 text-sm text-[#653d15] outline-none focus:border-[#e9a319] focus:ring-2 focus:ring-[#e9a319]/30"
               >
                 <option value="weak">Weak</option>
                 <option value="strong">Strong</option>
@@ -150,15 +133,14 @@ export default function AddTaskModal({ open, onClose, onCreate }) {
             <button
               type="button"
               onClick={onClose}
-              className="rounded-3xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+              className="rounded-3xl border-2 border-[#dbb96a] bg-[#f0ddb8] px-4 py-3 text-sm font-semibold text-[#653d15] hover:bg-[#dbb96a]"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={isOnCooldown}
-              className="rounded-3xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-60 disabled:bg-indigo-500"
-              title={isOnCooldown ? `Wait ${cooldownRemaining}s before creating another task` : "Create a new task"}
+              className="rounded-3xl bg-[#653d15] px-5 py-3 text-sm font-bold text-[#fdf6e3] shadow-sm hover:bg-[#4a2c0e] disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isOnCooldown ? `Wait ${cooldownRemaining}s` : "Create Task"}
             </button>

--- a/frontend/src/pages/dashboard/components/DashboardLayout.jsx
+++ b/frontend/src/pages/dashboard/components/DashboardLayout.jsx
@@ -6,6 +6,9 @@ export default function DashboardLayout({
   onQueryChange,
   onOpenFilters,
   onAddTask,
+  xp,
+  level,
+  streak,
   children,
 }) {
   return (
@@ -16,6 +19,9 @@ export default function DashboardLayout({
           onQueryChange={onQueryChange}
           onOpenFilters={onOpenFilters}
           onAddTask={onAddTask}
+          xp={xp}
+          level={level}
+          streak={streak}
         />
 
         <main className="flex-1 min-h-0">

--- a/frontend/src/pages/dashboard/components/TaskDashboard.jsx
+++ b/frontend/src/pages/dashboard/components/TaskDashboard.jsx
@@ -5,7 +5,8 @@ import Navbar from "./Navbar";
 import Footer from "./Footer";
 import XpBar from "./XpBar";
 import EditTaskModal from "./EditTaskModal";
-import { addXp } from "./xpSystem";
+import AddTaskModal from "./AddTaskModal";
+import { addXp, getLevel } from "./xpSystem";
 import { useAuth } from "@clerk/clerk-react";
 import { useTasks } from "../../../hooks/useTasks";
 import { ReactComponent as DoneIcon } from "../../../assets/Icons/done_icon.svg";
@@ -43,6 +44,7 @@ export default function TaskDashboard() {
   const [xp, setXp] = useState(0);
   const [xpWarning, setXpWarning] = useState("");
   const [editingTask, setEditingTask] = useState(null);
+  const [addModalOpen, setAddModalOpen] = useState(false);
   const [error, setError] = useState("");
 
   const { tasks: apiTasks, profile, loading } = useTasks();
@@ -111,8 +113,9 @@ export default function TaskDashboard() {
 
   const doneToday = tasks.filter((t) => t.completed).length;
   const displayStreak = profile?.streak ?? tasks.reduce((max, t) => Math.max(max, t.streak || 0), 0);
+  const displayLevel = getLevel(xp);
 
-  async function addTask({ title, description, type, strength }) {
+  async function handleCreateTask({ title, description, type, strength }) {
     setError("");
     try {
       const token = await getToken();
@@ -125,9 +128,7 @@ export default function TaskDashboard() {
         body: JSON.stringify({ title, description, type, strength }),
       });
 
-      if (!response.ok) {
-        throw new Error("Failed to create task.");
-      }
+      if (!response.ok) throw new Error("Failed to create task.");
 
       const createdTask = await response.json();
       setTasks((prev) => [createdTask, ...prev]);
@@ -145,7 +146,10 @@ export default function TaskDashboard() {
             query={query}
             onQueryChange={setQuery}
             onOpenFilters={() => {}}
-            onAddTask={addTask}
+            onAddTask={() => setAddModalOpen(true)}
+            xp={xp}
+            level={displayLevel}
+            streak={displayStreak}
           >
             {loading ? (
               <div className="flex items-center justify-center py-20 text-sm font-semibold text-[#9a6530]">
@@ -209,6 +213,12 @@ export default function TaskDashboard() {
         </div>
       </div>
       <Footer />
+
+      <AddTaskModal
+        open={addModalOpen}
+        onClose={() => setAddModalOpen(false)}
+        onCreate={handleCreateTask}
+      />
 
       <EditTaskModal
         open={editingTask !== null}


### PR DESCRIPTION
Restyled AddTaskModal and EditTaskModal to match the cream/brown theme. Fixed DashboardLayout to pass xp, level, and streak props to Header so the header stats show real values. Wired Add Task button to open AddTaskModal instead of creating a local stub task — tasks now POST to the backend on creation.