### PR TITLE
feat: add complete endpoints, xpClaimed, persist XP and streak

### DIFF
--- a/backend/src/main/java/com/taskkernel/controller/TaskController.java
+++ b/backend/src/main/java/com/taskkernel/controller/TaskController.java
@@ -24,17 +24,17 @@ public class TaskController {
     }
 
     @GetMapping
-public ResponseEntity<Map<String, Object>> getTasks() {
-    String userId = ClerkAuthUtil.getCurrentUserId();
-    List<Task> tasks = taskService.getTasksForUser(userId);
-    User userRecord = userService.getOrCreateUser(userId);
-    Map<String, Object> user = Map.of(
-            "xp", userRecord.getXp(),
-            "level", userRecord.getLevel(),
-            "streak", userRecord.getStreak()
-    );
-    return ResponseEntity.ok(Map.of("tasks", tasks, "user", user));
-}
+    public ResponseEntity<Map<String, Object>> getTasks() {
+        String userId = ClerkAuthUtil.getCurrentUserId();
+        List<Task> tasks = taskService.getTasksForUser(userId);
+        User userRecord = userService.getOrCreateUser(userId);
+        Map<String, Object> user = Map.of(
+                "xp", userRecord.getXp(),
+                "level", userRecord.getLevel(),
+                "streak", userRecord.getStreak()
+        );
+        return ResponseEntity.ok(Map.of("tasks", tasks, "user", user));
+    }
 
     @PostMapping
     public ResponseEntity<Task> createTask(@RequestBody Task task) {
@@ -54,5 +54,44 @@ public ResponseEntity<Map<String, Object>> getTasks() {
         String userId = ClerkAuthUtil.getCurrentUserId();
         taskService.deleteTask(id, userId);
         return ResponseEntity.ok(Map.of("message", "deleted"));
+    }
+
+    // Mark task complete — awards XP only if not already claimed
+    @PostMapping("/{id}/complete")
+    public ResponseEntity<Map<String, Object>> completeTask(@PathVariable Long id) {
+        String userId = ClerkAuthUtil.getCurrentUserId();
+        boolean wasXpClaimed = taskService.isXpClaimed(id, userId);
+        Task task = taskService.setCompleted(id, userId, true);
+        User user = wasXpClaimed
+                ? userService.getOrCreateUser(userId)
+                : userService.addXpForTask(userId, task);
+        return ResponseEntity.ok(Map.of(
+                "taskId", task.getId(),
+                "completed", true,
+                "xpClaimed", task.isXpClaimed(),
+                "user", Map.of(
+                        "xp", user.getXp(),
+                        "level", user.getLevel(),
+                        "streak", user.getStreak()
+                )
+        ));
+    }
+
+    // Unmark task complete — never removes XP
+    @DeleteMapping("/{id}/complete")
+    public ResponseEntity<Map<String, Object>> uncompleteTask(@PathVariable Long id) {
+        String userId = ClerkAuthUtil.getCurrentUserId();
+        Task task = taskService.setCompleted(id, userId, false);
+        User user = userService.getOrCreateUser(userId);
+        return ResponseEntity.ok(Map.of(
+                "taskId", task.getId(),
+                "completed", false,
+                "xpClaimed", task.isXpClaimed(),
+                "user", Map.of(
+                        "xp", user.getXp(),
+                        "level", user.getLevel(),
+                        "streak", user.getStreak()
+                )
+        ));
     }
 }

--- a/backend/src/main/java/com/taskkernel/entity/Task.java
+++ b/backend/src/main/java/com/taskkernel/entity/Task.java
@@ -12,7 +12,6 @@ public class Task {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // Clerk user ID — links task to the logged-in user
     @Column(name = "user_id", nullable = false)
     private String userId;
 
@@ -23,18 +22,20 @@ public class Task {
     @Column
     private String description;
 
-    // "daily" or "weekly"
     @NotNull
     @Column(nullable = false)
     private String type;
 
-    // "weak" or "strong"
     @NotNull
     @Column(nullable = false)
     private String strength;
 
     @Column(nullable = false)
     private boolean completed = false;
+
+    // Once XP is earned from this task it can never be earned again
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean xpClaimed = false;
 
     public Task() {}
 
@@ -45,8 +46,6 @@ public class Task {
         this.type = type;
         this.strength = strength;
     }
-
-    // Getters + Setters
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
@@ -68,4 +67,7 @@ public class Task {
 
     public boolean isCompleted() { return completed; }
     public void setCompleted(boolean completed) { this.completed = completed; }
+
+    public boolean isXpClaimed() { return xpClaimed; }
+    public void setXpClaimed(boolean xpClaimed) { this.xpClaimed = xpClaimed; }
 }

--- a/backend/src/main/java/com/taskkernel/service/TaskService.java
+++ b/backend/src/main/java/com/taskkernel/service/TaskService.java
@@ -50,4 +50,31 @@ public class TaskService {
 
         taskRepository.delete(existing);
     }
+
+    public boolean isXpClaimed(Long taskId, String clerkUserId) {
+        Task existing = taskRepository.findById(taskId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Task not found"));
+        if (!existing.getUserId().equals(clerkUserId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+        return existing.isXpClaimed();
+    }
+
+    public Task setCompleted(Long taskId, String clerkUserId, boolean completed) {
+        Task existing = taskRepository.findById(taskId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Task not found"));
+
+        if (!existing.getUserId().equals(clerkUserId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+
+        existing.setCompleted(completed);
+
+        // Mark XP as claimed the first time this task is completed — can never be earned again
+        if (completed && !existing.isXpClaimed()) {
+            existing.setXpClaimed(true);
+        }
+
+        return taskRepository.save(existing);
+    }
 }

--- a/backend/src/main/java/com/taskkernel/service/UserService.java
+++ b/backend/src/main/java/com/taskkernel/service/UserService.java
@@ -1,5 +1,6 @@
 package com.taskkernel.service;
 
+import com.taskkernel.entity.Task;
 import com.taskkernel.entity.User;
 import com.taskkernel.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,18 @@ public class UserService {
         user.setXp(xp);
         user.setLevel(level);
         user.setStreak(streak);
+        return userRepository.save(user);
+    }
+
+    // Awards XP based on task strength — strong = 20 XP, weak = 10 XP
+    public User addXpForTask(String clerkUserId, Task task) {
+        User user = getOrCreateUser(clerkUserId);
+        int xpGain = "strong".equals(task.getStrength()) ? 20 : 10;
+        int newXp = user.getXp() + xpGain;
+        int newLevel = (newXp / 100) + 1;
+        user.setXp(newXp);
+        user.setLevel(newLevel);
+        user.setStreak(user.getStreak() + 1);
         return userRepository.save(user);
     }
 }


### PR DESCRIPTION
Adds POST/DELETE /tasks/{id}/complete endpoints that save task completion state to the database. Adds xpClaimed field to Task entity so XP can only be earned once per task — checking and unchecking no longer awards XP multiple times. UserService.addXpForTask calculates XP based on task strength (strong = 20 XP, weak = 10 XP) and increments streak on completion.